### PR TITLE
TakeOptions now supports hide_selectors customization

### DIFF
--- a/src/TakeOptions.php
+++ b/src/TakeOptions.php
@@ -48,6 +48,20 @@ class TakeOptions
 
         return $this;
     }
+    
+    
+    /**
+     * The hide_selectors option allows hiding elements before taking a screenshot.
+     * All elements that match each selector will be hidden by setting the display style property to none !important.
+     */
+    public function hideSelectors(string ...$selectors)
+    {
+        foreach( $selectors as $selector ) {
+            $this->put('hide_selectors', $selector);
+        }
+
+        return $this;
+    }
 
     /**
      * errorOnSelectorNotFound determines the behavior of what to do when selector is not found.


### PR DESCRIPTION
## Description

This PR adds support for the `hide_selectors` customization by adding the `hideSelectors()` method to the `TakeOptions` class.

## Usage Example

```php
$options = TakeOptions::url($url)
    ->hideSelectors('.woocommerce-store-notice')
;
```