### PR TITLE
Add support for the ignore_host_errors option

### DIFF
--- a/src/TakeOptions.php
+++ b/src/TakeOptions.php
@@ -339,6 +339,16 @@ class TakeOptions
     }
 
     /**
+     * Ignore errors returned by the site and render the error page.
+     */
+    public function ignoreHostErrors(bool $ignoreHostErrors)
+    {
+        $this->put("ignore_host_errors", $ignoreHostErrors ? "true" : "false");
+
+        return $this;
+    }
+
+    /**
      * Returns array that might be used to build a query string.
      */
     public function query(): array


### PR DESCRIPTION
This change adds support for the `ignore_host_errors` option to allow creating and render screenshots even if the remote site returns errors, e.g. HTTP status code 404 ("File not found").

Resolves #3