### PR TITLE
Allow to pass custom client option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2      
       - uses: php-actions/composer@v6
-      - uses: php-actions/phpunit@v3
+      - uses: php-actions/phpunit@v4

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         }
     ],
     "require": {
+        "php": ">=7.4",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -21,11 +21,11 @@ class Client
     private string $secretKey;
 
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, mixed> $httpClientOptions
      */
-    public function __construct(string $accessKey, string $secretKey, array $options = [])
+    public function __construct(string $accessKey, string $secretKey, array $httpClientOptions = [])
     {
-        $this->httpClient = new HttpClient($options + [
+        $this->httpClient = new HttpClient($httpClientOptions + [
             // max possible timeout for the API requests
             'timeout'  => 600,
             'allow_redirects' => true,

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,9 +20,12 @@ class Client
     private string $accessKey;
     private string $secretKey;
 
-    public function __construct(string $accessKey, string $secretKey)
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(string $accessKey, string $secretKey, array $options = [])
     {
-        $this->httpClient = new HttpClient([
+        $this->httpClient = new HttpClient($options + [
             // max possible timeout for the API requests
             'timeout'  => 600,
             'allow_redirects' => true,


### PR DESCRIPTION
Hi @krasun ; I discovered that the client timeout (and other options) was hardcoded.

I feel like it would be great to allow to override those defaults.

Also no php requirement was defined in the composer.json, but the fact you're using arrow function imply that it requires PHP 7.4 or more, so I added it to the composer.json.